### PR TITLE
bug fix for pytorch version mismatch - Update test_pt.py.

### DIFF
--- a/tutorials/img_cls/test_pt.py
+++ b/tutorials/img_cls/test_pt.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
 
 
     ## inference
-    images, labels = dataiter.next()
+    images, labels = next(dataiter)
     print('Ground-truth: ', ' '.join('%5s' % classes[labels[j]] for j in range(4)))
 
     outputs = model(images)


### PR DESCRIPTION
PR #4  did not update for the `test_pt.py` file, and therefore it produces an `AttributeError: '_MultiProcessingDataLoaderIter' object has no attribute 'next'` when run.
Therefore I changed `dataiter.next()` to  `next(dataiter)` like in `train_pt.py` which fixes this issue.